### PR TITLE
Only generate manifest when fingerprinting

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -34,7 +34,7 @@ class Fingerprint
       autoReplaceAndHash: false
       # public root path ( for multi theme support)
       publicRootPath: '/public'
-      
+
       # Assets pattern
       assetsPattern: new RegExp(/url\([\'\"]?[a-zA-Z0-9\-\/_.:]+\.(woff|woff2|eot|ttf|otf|jpg|jpeg|png|bmp|gif|svg)\??\#?[a-zA-Z0-9\-\/_]*[\'\"]?\)/g)
       # URL parameters pattern
@@ -227,14 +227,16 @@ class Fingerprint
 
   # Write a new manifest
   _writeManifest: ->
-    output = JSON.stringify @map, null, "  "
-    fs.writeFileSync(@options.manifest, output)
+    if @_isFingerprintable()
+      output = JSON.stringify @map, null, "  "
+      fs.writeFileSync(@options.manifest, output)
 
   # Merging existing manifest with new entree
   _mergeManifest: ->
-    manifest = fs.readFileSync @options.manifest, 'utf8'
-    manifest = JSON.parse manifest
-    manifest[k] = @map[k] for k of @map
-    @_writeManifest(manifest)
+    if @_isFingerprintable()
+      manifest = fs.readFileSync @options.manifest, 'utf8'
+      manifest = JSON.parse manifest
+      manifest[k] = @map[k] for k of @map
+      @_writeManifest(manifest)
 
 module.exports = Fingerprint

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -183,21 +183,24 @@ describe 'Fingerprint', ->
     beforeEach ->
       setupFakeFileSystem()
 
+    didRun = ->
+      fingerprintFileExists('js/sample.js') &&
+        fs.existsSync(fingerprint.options.manifest)
+
     it 'does not run in non-production environment', ->
       fingerprint.config.env = []
       fingerprint.onCompile(GENERATED_FILES)
-      expect(fingerprintFileExists('js/sample.js')).to.be.false
+      expect(didRun()).to.be.false
 
     it 'does run with alwaysRun flag set', ->
       fingerprint.options.alwaysRun = true
       fingerprint.onCompile(GENERATED_FILES)
-      expect(fingerprintFileExists('js/sample.js')).to.be.true
+      expect(didRun()).to.be.true
 
     it 'does run in production environment', ->
       fingerprint.options.env = ['production']
       fingerprint.onCompile(GENERATED_FILES)
-      expect(fingerprintFileExists('js/sample.js')).to.be.true
-
+      expect(didRun()).to.be.true
 
   # Matching assets to hash
   describe 'AutoReplace inner assets', ->


### PR DESCRIPTION
Currently fingerprint generates manifest files even when it's supposedly not running (in development environment in my case). This PR makes sure that nothing is generated when the plugin is turned off.