### PR TITLE
Remove brunch peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
     "mocha": "~2.1.0",
     "fs-extra": "~0.16.3"
   },
-  "license": "MIT",
-  "peerDependencies": {
-    "brunch": "~1.8"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
I'm using `brunch@2.6.1` in my app and if I try to install `fingerprint-brunch`, `npm@2` throws an error.

Removing the peer dependency fixes it, and seems to be the pattern followed by other plugins (for ex: https://github.com/brunch/javascript-brunch/blob/master/package.json).

I've tested with `brunch@2.6.1` and things seem to work.