### PR TITLE
add missing callback when clearing old file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,9 @@ class Fingerprint {
       if (err) return done && done(err);
       for (let oldFile of Array.from(files)) {
         const filePath = path.normalize(dir + '/' + oldFile);
-        if (pattern.test(oldFile)) fs.unlink(filePath);
+        if (pattern.test(oldFile)) fs.unlink(filePath, function(err) {
+          if (err) return done && done(err);
+        });
       }
       done && done()
     });


### PR DESCRIPTION
With the following option set below,

`
autoClearOldFiles: true
`

The build process would throw an invalid callback error when encountering a file that was to be deleted.

The unlink function was missing a needed callback [fs.unlink(path, callback)](https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback)

