### PR TITLE
Adding an assetsPrefix option to prepend to replaced assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ _Optional_ You can override fingerprint-brunch's default options by updating you
   - Force fingerprint-brunch to run in all environments when true.
 * __autoReplaceAndHash__: _(`Boolean`)_ Defaults to `false`
   - Find assets in your `jointTo` files. It will be finded with `url('path/to/assets.jpg')` in your css (for now)
+* __assetsPrefix__: _(`Boolean|String`)_ Defaults to `false`
+  - Prefix to prepend to replaced assets.
 * __publicRootPath__: _(`string`)_ Defaults to `/public`
   - For support multiple themes, you can set the public root path, exemple :
   - My config.paths.public is `../../public/theme/theme-1/` in `css` your fonts, images will be linked like that : `/theme/theme-1/img/troll.png`. 
@@ -114,6 +116,35 @@ Use `srcBasePath` and `destBasePath` to remove some part of path files in the ma
 
 ## <a name="options"></a> Options
 
+### assetsPrefix
+
+Sometimes you may want to add a prefix to assets when replacing their path in your compiled css/js.
+
+Say you have a CSS file containing:
+
+```css
+.logo {
+  background-image: url('logo.svg');
+}
+```
+
+once replaced, the content would look like:
+
+```css
+.logo {
+  background-image: url('logo-f98d59ab3.svg');
+}
+```
+
+if you were to set `assetsPrefix: '/custom/'` the result would be:
+
+```css
+.logo {
+  background-image: url('/custom/logo-f98d59ab3.svg');
+}
+```
+
+_Note: This could also be leveraged to prepend a CDN url for instance._
 
 ## <a name="testing"></a> Testing / Issues
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,8 @@ class Fingerprint {
       alwaysRun: false,
       // autoReplaceAndHash assets in css/js, like a font linked in an url() in your css
       autoReplaceAndHash: false,
+      // prefix to prepend to assets replaced in css/js files
+      assetsPrefix: false,
       // public root path ( for multi theme support) !!! put a './' before your path
       publicRootPath: './public',
       // Force the generation of the manifest, event if there are no fingerprinted files
@@ -270,8 +272,12 @@ class Fingerprint {
     this._getFingerprintAllData(filePath, (data) => {
       if (data.filePaths !== null) {
         that._fingerprintAllResolver(data.filePaths, (resolve, targetNewName, finalHash, match) => {
+          targetNewName = that.unixify(targetNewName.substring(that.options.publicRootPath.length - 2));
+          if (that.options.assetsPrefix) {
+            targetNewName = `${that.options.assetsPrefix}${targetNewName}`;
+          }
           // Add real path into the css file
-          data.fileContent = data.fileContent.replace(match, `url('${that.unixify(targetNewName.substring(that.options.publicRootPath.length - 2))}${finalHash}')`);
+          data.fileContent = data.fileContent.replace(match, `url('${targetNewName}${finalHash}')`);
           resolve();
         }, () => {
           let fileNewName = filePath;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -539,9 +539,23 @@ describe('Fingerprint', () => {
         // Expect parent file well fingerprinted
         expect(typeof(fingerprint.map[fingerprint.unixify(filePath)])).to.be.not.equal('undefined');
         expect(typeof(fingerprint.map[fingerprint.unixify(filePath)])).to.be.not.equal(undefined);
-        expect(fingerprint.map[fingerprint.unixify(filePath)]).to.be.not.equal(fingerprint.unixify(filePath));  
+        expect(fingerprint.map[fingerprint.unixify(filePath)]).to.be.not.equal(fingerprint.unixify(filePath));
         done();
       });
+    });
+  });
+
+  describe('Prefixing AutReplaced assets', function() {
+    it('should prepend the prefix to autoreplaced assets', function(done) {
+      fingerprint.options.alwaysRun = true;
+      fingerprint.options.autoReplaceAndHash = true;
+      fingerprint.options.assetsPrefix = 'TestPrefix';
+      fingerprint._fingerprintAllAsync(path.join(__dirname, 'public', 'css', 'sample-2.css'), (err, filePath) => {
+        fs.readFile(filePath, (err, data) => {
+          expect(data).to.match(/url\(TestPrefix\/img\/troll.png\)/)
+        });
+      });
+      done()
     });
   });
 


### PR DESCRIPTION
Following on #41 this is a PR proposal to add an `assetsPrefix` option to prepend text to the replaced assets in css/js.